### PR TITLE
Minor fixes to make code compile for VSCODE

### DIFF
--- a/ArduinoCore-API/api/Common.h
+++ b/ArduinoCore-API/api/Common.h
@@ -72,10 +72,14 @@ typedef void (*voidFuncPtrParam)(void*);
 #define bit(b) (1UL << (b))
 #endif
 
+#ifdef SKIP_LEGACY_TYPES
 /* TODO: request for removal */
-// typedef bool      boolean;
-// typedef uint8_t   byte;
-// typedef uint16_t  word;
+#else
+// Keep these legacy types as they expected to be defined by Arduino.h and may be used by user code
+typedef bool      boolean;
+typedef uint8_t   byte;
+typedef uint16_t  word;
+#endif
 
 void init(void);
 void initVariant(void);

--- a/ArduinoCore-API/api/Stream.cpp
+++ b/ArduinoCore-API/api/Stream.cpp
@@ -86,7 +86,7 @@ int Stream::peekNextDigit(LookaheadMode lookahead, bool detectDecimal)
 // Public Methods
 //////////////////////////////////////////////////////////////
 
-void Stream::setTimeout(unsigned long timeout)  // sets the maximum number of milliseconds to wait
+void Stream::setTimeout(size_t timeout)  // sets the maximum number of milliseconds to wait
 {
   _timeout = timeout;
 }


### PR DESCRIPTION
Fixed definition of setTimeout (as size_t may not be unsigned long, and its is not under VSCODE)

Added back legacy types. While idea to remove them from core looks reasonable, they are expected to be defined by user code (and practically, used widely in may sketches).