### PR TITLE
Added case for print zero value long long

### DIFF
--- a/ArduinoCore-API/api/Print.cpp
+++ b/ArduinoCore-API/api/Print.cpp
@@ -287,6 +287,12 @@ size_t Print::printULLNumber(unsigned long long n64, uint8_t base)
   uint8_t i = 0;
   uint8_t innerLoops = 0;
 
+  // Special case workaround https://github.com/arduino/ArduinoCore-API/issues/178
+  if (n64 == 0) {
+    write('0');
+    return 1;
+  }
+
   // prevent crash if called with base == 1
   if (base < 2) base = 10;
 


### PR DESCRIPTION
The value of long long 0 not printed (skipped).
The issue was fixed in Arduino API ref source, so it backported here