### PR TITLE
Added emptyString for compatibility with other Arduino cores

### DIFF
--- a/ArduinoCore-Linux/cores/arduino/Arduino.cpp
+++ b/ArduinoCore-Linux/cores/arduino/Arduino.cpp
@@ -232,3 +232,5 @@ void analogWriteResolution(uint8_t bits) {
  * @note This is used to prevent watchdog timer resets in long-running loops
  */
 void yield() {}
+
+const String emptyString;

--- a/ArduinoCore-Linux/cores/arduino/Arduino.h
+++ b/ArduinoCore-Linux/cores/arduino/Arduino.h
@@ -50,3 +50,7 @@ using namespace arduino;
 // supported by some platforms
 void analogWriteFrequency(pin_size_t pin, uint32_t freq);
 void analogWriteResolution(uint8_t bits);
+
+// ESP32-ism that is adopted by most Arduino implementations
+// and used by, at least, ESPAsyncWebServer
+extern const String emptyString;


### PR DESCRIPTION
Many Arduino cores, including ESP32, pico, and libretiny, implement "String emptyString" to save space.  ESPAsyncWebServer requires it.  I tried adding a private _emptyString to ESPAsyncWebServer but it turned into a mess, so it seems best to implement it here to align with other cores.