### PR TITLE
Align connection timing with other cores

### DIFF
--- a/ArduinoCore-Linux/cores/arduino/Ethernet.h
+++ b/ArduinoCore-Linux/cores/arduino/Ethernet.h
@@ -22,7 +22,10 @@
 #include <arpa/inet.h>  // for inet_pton
 #include <netdb.h>      // for gethostbyname, struct hostent
 #include <unistd.h>     // for close
+#include <chrono>
+#include <future>
 #include <memory>  // This is the include you need
+#include <thread>
 
 #include "ArduinoLogger.h"
 #include "RingBufferExt.h"
@@ -170,15 +173,13 @@ class EthernetClient : public Client {
 
   // checks if we are connected - using a timeout
   virtual uint8_t connected() override {
-    if (!is_connected) return false;       // connect has failed
-    if (p_sock->connected()) return true;  // check socket
-    long timeout = millis() + getConnectionTimeout();
-    uint8_t result = p_sock->connected();
-    while (result <= 0 && millis() < timeout) {
-      delay(200);
-      result = p_sock->connected();
-    }
-    return result;
+    if (!is_connected || !p_sock) return false;
+
+    // A disconnected socket should be reported immediately. Retrying here
+    // turns normal peer shutdown into a multi-second stall for callers like
+    // TelnetClient::closeOnDisconnect().
+    is_connected = p_sock->connected();
+    return is_connected;
   }
 
   // support conversion to bool
@@ -186,32 +187,50 @@ class EthernetClient : public Client {
 
   // opens a conection
   virtual int connect(IPAddress ipAddress, uint16_t port) override {
+    return connect(ipAddress, port, getConnectionTimeout());
+  }
+
+  int connect(IPAddress ipAddress, uint16_t port, int32_t timeout_ms) {
     String str = String(ipAddress[0]) + String(".") + String(ipAddress[1]) +
                  String(".") + String(ipAddress[2]) + String(".") +
                  String(ipAddress[3]);
     this->address = ipAddress;
     this->port = port;
-    return connect(str.c_str(), port);
+    return connect(str.c_str(), port, timeout_ms);
   }
 
   // opens a connection
   virtual int connect(const char* address, uint16_t port) override {
+    return connect(address, port, getConnectionTimeout());
+  }
+
+  int connect(const char* address, uint16_t port, int32_t timeout_ms) {
     Logger.info(WIFICLIENT, "connect");
     this->port = port;
     if (connectedFast()) {
       p_sock->close();
     }
-    IPAddress adr = resolveAddress(address, port);
+    uint32_t start_ms = millis();
+    IPAddress adr = resolveAddress(address, timeout_ms);
     if (adr == IPAddress(0, 0, 0, 0)) {
       is_connected = false;
       return 0;
     }
+
+    int32_t remaining_timeout = timeout_ms;
+    if (timeout_ms >= 0) {
+      uint32_t elapsed_ms = millis() - start_ms;
+      remaining_timeout = elapsed_ms >= static_cast<uint32_t>(timeout_ms)
+                              ? 0
+                              : timeout_ms - static_cast<int32_t>(elapsed_ms);
+    }
+
     // performs the actual connection
     String str = adr.toString();
     Logger.info("Connecting to ", str.c_str());
-    p_sock->connect(str.c_str(), port);
-    is_connected = true;
-    return 1;
+    int result = p_sock->connect(str.c_str(), port, remaining_timeout);
+    is_connected = result > 0;
+    return is_connected ? 1 : 0;
   }
 
   virtual size_t write(char c) { return write((uint8_t)c); }
@@ -334,21 +353,67 @@ class EthernetClient : public Client {
   IPAddress address{0, 0, 0, 0};
   uint16_t port = 0;
 
+  IPAddress resolveHostnameWithTimeout(const char* hostname, int32_t timeout_ms) {
+    if (timeout_ms < 0) {
+      struct addrinfo hints;
+      memset(&hints, 0, sizeof(hints));
+      hints.ai_family = AF_INET;
+      hints.ai_socktype = SOCK_STREAM;
+
+      struct addrinfo* result = nullptr;
+      if (getaddrinfo(hostname, nullptr, &hints, &result) != 0 || result == nullptr) {
+        Logger.error(WIFICLIENT, "Hostname resolution failed");
+        return IPAddress(0, 0, 0, 0);
+      }
+
+      auto* addr = reinterpret_cast<struct sockaddr_in*>(result->ai_addr);
+      IPAddress resolved(addr->sin_addr.s_addr);
+      freeaddrinfo(result);
+      return resolved;
+    }
+
+    auto promise = std::make_shared<std::promise<IPAddress>>();
+    auto future = promise->get_future();
+    std::string hostname_copy(hostname);
+
+    std::thread resolver([promise, hostname_copy]() {
+      struct addrinfo hints;
+      memset(&hints, 0, sizeof(hints));
+      hints.ai_family = AF_INET;
+      hints.ai_socktype = SOCK_STREAM;
+
+      struct addrinfo* result = nullptr;
+      IPAddress resolved(0, 0, 0, 0);
+      if (getaddrinfo(hostname_copy.c_str(), nullptr, &hints, &result) == 0 && result != nullptr) {
+        auto* addr = reinterpret_cast<struct sockaddr_in*>(result->ai_addr);
+        resolved = IPAddress(addr->sin_addr.s_addr);
+        freeaddrinfo(result);
+      }
+      promise->set_value(resolved);
+    });
+
+    auto status = future.wait_for(std::chrono::milliseconds(timeout_ms));
+    if (status == std::future_status::ready) {
+      resolver.join();
+      auto resolved = future.get();
+      if (resolved == IPAddress(0, 0, 0, 0)) {
+        Logger.error(WIFICLIENT, "Hostname resolution failed");
+      }
+      return resolved;
+    }
+
+    resolver.detach();
+    Logger.error(WIFICLIENT, "Hostname resolution timeout");
+    return IPAddress(0, 0, 0, 0);
+  }
+
   // resolves the address and returns sockaddr_in
-  IPAddress resolveAddress(const char* address, uint16_t port) {
+  IPAddress resolveAddress(const char* address, int32_t timeout_ms) {
     struct sockaddr_in serv_addr4;
     memset(&serv_addr4, 0, sizeof(serv_addr4));
     serv_addr4.sin_family = AF_INET;
-    serv_addr4.sin_port = htons(port);
     if (::inet_pton(AF_INET, address, &serv_addr4.sin_addr) <= 0) {
-      // Not an IP, try to resolve hostname
-      struct hostent* he = ::gethostbyname(address);
-      if (he == nullptr || he->h_addr_list[0] == nullptr) {
-        Logger.error(WIFICLIENT, "Hostname resolution failed");
-        serv_addr4.sin_addr.s_addr = 0;
-      } else {
-        memcpy(&serv_addr4.sin_addr, he->h_addr_list[0], he->h_length);
-      }
+      return resolveHostnameWithTimeout(address, timeout_ms);
     }
     return IPAddress(serv_addr4.sin_addr.s_addr);
   }

--- a/ArduinoCore-Linux/cores/arduino/Ethernet.h
+++ b/ArduinoCore-Linux/cores/arduino/Ethernet.h
@@ -294,11 +294,13 @@ class EthernetClient : public Client {
   }
 
   virtual size_t readBytes(char* buffer, size_t len) {
-    return read((uint8_t*)buffer, len);
+    int result = read((uint8_t*)buffer, len);
+    return result < 0 ? 0 : static_cast<size_t>(result);
   }
 
   virtual size_t readBytes(uint8_t* buffer, size_t len) {
-    return read(buffer, len);
+    int result = read(buffer, len);
+    return result < 0 ? 0 : static_cast<size_t>(result);
   }
 
   // peeks one character
@@ -384,11 +386,11 @@ class EthernetClient : public Client {
     int result = 0;
     long timeout = millis() + getTimeout();
     result = p_sock->read(buffer, len);
-    while (result <= 0 && millis() < timeout) {
+    while (result == 0 && millis() < timeout) {
       delay(200);
       result = p_sock->read(buffer, len);
     }
-    //}
+
     char lenStr[16];
     sprintf(lenStr, "%d", result);
     Logger.debug(WIFICLIENT, "read->", lenStr);

--- a/ArduinoCore-Linux/cores/arduino/Ethernet.h
+++ b/ArduinoCore-Linux/cores/arduino/Ethernet.h
@@ -22,10 +22,7 @@
 #include <arpa/inet.h>  // for inet_pton
 #include <netdb.h>      // for gethostbyname, struct hostent
 #include <unistd.h>     // for close
-#include <chrono>
-#include <future>
 #include <memory>  // This is the include you need
-#include <thread>
 
 #include "ArduinoLogger.h"
 #include "RingBufferExt.h"
@@ -210,25 +207,16 @@ class EthernetClient : public Client {
     if (connectedFast()) {
       p_sock->close();
     }
-    uint32_t start_ms = millis();
-    IPAddress adr = resolveAddress(address, timeout_ms);
+    IPAddress adr = resolveAddress(address);
     if (adr == IPAddress(0, 0, 0, 0)) {
       is_connected = false;
       return 0;
     }
 
-    int32_t remaining_timeout = timeout_ms;
-    if (timeout_ms >= 0) {
-      uint32_t elapsed_ms = millis() - start_ms;
-      remaining_timeout = elapsed_ms >= static_cast<uint32_t>(timeout_ms)
-                              ? 0
-                              : timeout_ms - static_cast<int32_t>(elapsed_ms);
-    }
-
     // performs the actual connection
     String str = adr.toString();
     Logger.info("Connecting to ", str.c_str());
-    int result = p_sock->connect(str.c_str(), port, remaining_timeout);
+    int result = p_sock->connect(str.c_str(), port, timeout_ms);
     is_connected = result > 0;
     return is_connected ? 1 : 0;
   }
@@ -353,67 +341,31 @@ class EthernetClient : public Client {
   IPAddress address{0, 0, 0, 0};
   uint16_t port = 0;
 
-  IPAddress resolveHostnameWithTimeout(const char* hostname, int32_t timeout_ms) {
-    if (timeout_ms < 0) {
-      struct addrinfo hints;
-      memset(&hints, 0, sizeof(hints));
-      hints.ai_family = AF_INET;
-      hints.ai_socktype = SOCK_STREAM;
+  IPAddress resolveHostname(const char* hostname) {
+    struct addrinfo hints;
+    memset(&hints, 0, sizeof(hints));
+    hints.ai_family = AF_INET;
+    hints.ai_socktype = SOCK_STREAM;
 
-      struct addrinfo* result = nullptr;
-      if (getaddrinfo(hostname, nullptr, &hints, &result) != 0 || result == nullptr) {
-        Logger.error(WIFICLIENT, "Hostname resolution failed");
-        return IPAddress(0, 0, 0, 0);
-      }
-
-      auto* addr = reinterpret_cast<struct sockaddr_in*>(result->ai_addr);
-      IPAddress resolved(addr->sin_addr.s_addr);
-      freeaddrinfo(result);
-      return resolved;
+    struct addrinfo* result = nullptr;
+    if (getaddrinfo(hostname, nullptr, &hints, &result) != 0 || result == nullptr) {
+      Logger.error(WIFICLIENT, "Hostname resolution failed");
+      return IPAddress(0, 0, 0, 0);
     }
 
-    auto promise = std::make_shared<std::promise<IPAddress>>();
-    auto future = promise->get_future();
-    std::string hostname_copy(hostname);
-
-    std::thread resolver([promise, hostname_copy]() {
-      struct addrinfo hints;
-      memset(&hints, 0, sizeof(hints));
-      hints.ai_family = AF_INET;
-      hints.ai_socktype = SOCK_STREAM;
-
-      struct addrinfo* result = nullptr;
-      IPAddress resolved(0, 0, 0, 0);
-      if (getaddrinfo(hostname_copy.c_str(), nullptr, &hints, &result) == 0 && result != nullptr) {
-        auto* addr = reinterpret_cast<struct sockaddr_in*>(result->ai_addr);
-        resolved = IPAddress(addr->sin_addr.s_addr);
-        freeaddrinfo(result);
-      }
-      promise->set_value(resolved);
-    });
-
-    auto status = future.wait_for(std::chrono::milliseconds(timeout_ms));
-    if (status == std::future_status::ready) {
-      resolver.join();
-      auto resolved = future.get();
-      if (resolved == IPAddress(0, 0, 0, 0)) {
-        Logger.error(WIFICLIENT, "Hostname resolution failed");
-      }
-      return resolved;
-    }
-
-    resolver.detach();
-    Logger.error(WIFICLIENT, "Hostname resolution timeout");
-    return IPAddress(0, 0, 0, 0);
+    auto* addr = reinterpret_cast<struct sockaddr_in*>(result->ai_addr);
+    IPAddress resolved(addr->sin_addr.s_addr);
+    freeaddrinfo(result);
+    return resolved;
   }
 
   // resolves the address and returns sockaddr_in
-  IPAddress resolveAddress(const char* address, int32_t timeout_ms) {
+  IPAddress resolveAddress(const char* address) {
     struct sockaddr_in serv_addr4;
     memset(&serv_addr4, 0, sizeof(serv_addr4));
     serv_addr4.sin_family = AF_INET;
     if (::inet_pton(AF_INET, address, &serv_addr4.sin_addr) <= 0) {
-      return resolveHostnameWithTimeout(address, timeout_ms);
+      return resolveHostname(address);
     }
     return IPAddress(serv_addr4.sin_addr.s_addr);
   }

--- a/ArduinoCore-Linux/cores/arduino/NetworkClientSecure.h
+++ b/ArduinoCore-Linux/cores/arduino/NetworkClientSecure.h
@@ -63,7 +63,7 @@ class SocketImplSecure : public SocketImpl {
     }
   }
   // direct read
-  size_t read(uint8_t* buffer, size_t len) {
+  int read(uint8_t* buffer, size_t len) override {
     // size_t result = ::recv(sock, buffer, len, MSG_DONTWAIT );
     if (ssl == nullptr) {
       wolfSSL_set_fd(ssl, sock);
@@ -71,8 +71,20 @@ class SocketImplSecure : public SocketImpl {
     int result = ::wolfSSL_read(ssl, buffer, len);
 
     if (result < 0) {
-      result = 0;
+      int error = wolfSSL_get_error(ssl, result);
+      if (error == SSL_ERROR_WANT_READ || error == SSL_ERROR_WANT_WRITE) {
+        return 0;
+      }
+
+      is_connected = false;
+      return -1;
     }
+
+    if (result == 0) {
+      is_connected = false;
+      return -1;
+    }
+
     // 
     char lenStr[80];
     sprintf(lenStr, "%ld -> %d", len, result);

--- a/ArduinoCore-Linux/cores/arduino/SocketImpl.cpp
+++ b/ArduinoCore-Linux/cores/arduino/SocketImpl.cpp
@@ -158,10 +158,9 @@ int SocketImpl::connect(const char *address, uint16_t port, int32_t timeout_ms) 
       FD_ZERO(&errorfds);
       FD_SET(sock, &errorfds);
 
-      timeval timeout {
-        .tv_sec = timeout_ms / 1000,
-        .tv_usec = (timeout_ms % 1000) * 1000,
-      };
+      timeval timeout;
+      timeout.tv_sec = timeout_ms / 1000;
+      timeout.tv_usec = (timeout_ms % 1000) * 1000;
 
       result = select(sock + 1, nullptr, &writefds, &errorfds, &timeout);
       if (result == 0) {

--- a/ArduinoCore-Linux/cores/arduino/SocketImpl.cpp
+++ b/ArduinoCore-Linux/cores/arduino/SocketImpl.cpp
@@ -26,10 +26,12 @@
 #include <net/if.h>
 #include <netdb.h>
 #include <netinet/in.h>
+#include <sys/select.h>
 #include <sys/ioctl.h>
 #include <sys/socket.h>
 #include <sys/types.h>
 #include <unistd.h>
+#include <cerrno>
 #ifdef __APPLE__
 #include <net/route.h>
 #include <sys/sysctl.h>
@@ -48,30 +50,57 @@ uint8_t SocketImpl::connected() {
   if (sock < 0) return false;
   char buf[2];
   int result = ::recv(sock, &buf, 1, MSG_PEEK | MSG_DONTWAIT);
-  // if peek is working we are connected - if not we do further checks
-  is_connected = result >= 0;
-  if (!is_connected) {
-    int error_code;
-    socklen_t error_code_size;
-    // int getsockopt(int sockfd, int level, int optname,void *optval, socklen_t
-    // *optlen);
-    int result =
-        getsockopt(sock, SOL_SOCKET, SO_ERROR, &error_code, &error_code_size);
-    if (result != 0) {
-      char msg[50];
-      sprintf(msg, "%d", result);
-      Logger.debug(SOCKET_IMPL, "getsockopt->", msg);
-    }
-
-    is_connected = (result == 0);
+  if (result > 0) {
+    is_connected = true;
+    return true;
   }
 
-  return is_connected;
+  if (result == 0) {
+    Logger.info(SOCKET_IMPL, "peer closed connection");
+    close();
+    is_connected = false;
+    return false;
+  }
+
+  if (errno == EAGAIN || errno == EWOULDBLOCK) {
+    is_connected = true;
+    return true;
+  }
+
+  int error_code = 0;
+  socklen_t error_code_size = sizeof(error_code);
+  // int getsockopt(int sockfd, int level, int optname,void *optval, socklen_t
+  // *optlen);
+  int sockopt_result =
+      getsockopt(sock, SOL_SOCKET, SO_ERROR, &error_code, &error_code_size);
+  if (sockopt_result != 0) {
+    char msg[50];
+    sprintf(msg, "%d", sockopt_result);
+    Logger.debug(SOCKET_IMPL, "getsockopt->", msg);
+  }
+
+  if (sockopt_result == 0 && error_code == 0) {
+    is_connected = true;
+    return true;
+  }
+
+  close();
+  is_connected = false;
+  return false;
 }
 
 // opens a conection
 int SocketImpl::connect(const char *address, uint16_t port) {
+  return connect(address, port, -1);
+}
+
+int SocketImpl::connect(const char *address, uint16_t port, int32_t timeout_ms) {
+  if (sock >= 0) {
+    close();
+  }
+
   if ((sock = ::socket(AF_INET, SOCK_STREAM, 0)) < 0) {
+    is_connected = false;
     Logger.error(SOCKET_IMPL, "could not create socket");
     return -1;
   }
@@ -89,13 +118,77 @@ int SocketImpl::connect(const char *address, uint16_t port) {
 
   // Convert IPv4 and IPv6 addresses from text to binary form
   if (::inet_pton(AF_INET, address_ip, &serv_addr.sin_addr) <= 0) {
+    close();
     Logger.error(SOCKET_IMPL, "invalid address");
     return -2;
   }
 
-  if (::connect(sock, (struct sockaddr *)&serv_addr, sizeof(serv_addr)) < 0) {
-    Logger.error(SOCKET_IMPL, "could not connect");
-    return -3;
+  if (timeout_ms < 0) {
+    if (::connect(sock, (struct sockaddr *)&serv_addr, sizeof(serv_addr)) < 0) {
+      close();
+      Logger.error(SOCKET_IMPL, "could not connect");
+      return -3;
+    }
+  } else {
+    int flags = fcntl(sock, F_GETFL, 0);
+    if (flags < 0) {
+      flags = 0;
+    }
+
+    if (fcntl(sock, F_SETFL, flags | O_NONBLOCK) < 0) {
+      close();
+      Logger.error(SOCKET_IMPL, "could not set nonblocking connect");
+      return -3;
+    }
+
+    int result = ::connect(sock, (struct sockaddr *)&serv_addr, sizeof(serv_addr));
+    if (result < 0) {
+      if (errno != EINPROGRESS && errno != EWOULDBLOCK) {
+        fcntl(sock, F_SETFL, flags);
+        close();
+        Logger.error(SOCKET_IMPL, "could not connect");
+        return -3;
+      }
+
+      fd_set writefds;
+      FD_ZERO(&writefds);
+      FD_SET(sock, &writefds);
+
+      fd_set errorfds;
+      FD_ZERO(&errorfds);
+      FD_SET(sock, &errorfds);
+
+      timeval timeout {
+        .tv_sec = timeout_ms / 1000,
+        .tv_usec = (timeout_ms % 1000) * 1000,
+      };
+
+      result = select(sock + 1, nullptr, &writefds, &errorfds, &timeout);
+      if (result == 0) {
+        fcntl(sock, F_SETFL, flags);
+        close();
+        Logger.error(SOCKET_IMPL, "connect timeout");
+        return -4;
+      }
+
+      if (result < 0) {
+        fcntl(sock, F_SETFL, flags);
+        close();
+        Logger.error(SOCKET_IMPL, "select failed during connect");
+        return -3;
+      }
+
+      int error_code = 0;
+      socklen_t error_len = sizeof(error_code);
+      if (getsockopt(sock, SOL_SOCKET, SO_ERROR, &error_code, &error_len) != 0 || error_code != 0) {
+        fcntl(sock, F_SETFL, flags);
+        close();
+        Logger.error(SOCKET_IMPL, "could not connect");
+        return -3;
+      }
+    }
+
+    fcntl(sock, F_SETFL, flags);
   }
 
   is_connected = true;
@@ -112,8 +205,24 @@ size_t SocketImpl::write(const uint8_t *str, size_t len) {
 
 // provides the available bytes
 size_t SocketImpl::available() {
+  if (sock < 0) {
+    is_connected = false;
+    return 0;
+  }
+
   int bytes_available;
-  ioctl(sock, FIONREAD, &bytes_available);
+  if (ioctl(sock, FIONREAD, &bytes_available) != 0) {
+    if (errno != EAGAIN && errno != EWOULDBLOCK) {
+      close();
+      is_connected = false;
+    }
+    return 0;
+  }
+
+  if (bytes_available == 0 && !connected()) {
+    return 0;
+  }
+
   char msg[50];
   sprintf(msg, "%d", bytes_available);
   Logger.debug(SOCKET_IMPL, "available->", msg);
@@ -122,7 +231,27 @@ size_t SocketImpl::available() {
 
 // direct read
 size_t SocketImpl::read(uint8_t *buffer, size_t len) {
-  size_t result = ::recv(sock, buffer, len, MSG_DONTWAIT | MSG_NOSIGNAL);
+  if (sock < 0) {
+    is_connected = false;
+    return static_cast<size_t>(-1);
+  }
+
+  ssize_t result = ::recv(sock, buffer, len, MSG_DONTWAIT | MSG_NOSIGNAL);
+  if (result == 0) {
+    Logger.info(SOCKET_IMPL, "read EOF");
+    close();
+    is_connected = false;
+    return static_cast<size_t>(-1);
+  }
+
+  if (result < 0) {
+    if (errno != EAGAIN && errno != EWOULDBLOCK) {
+      close();
+      is_connected = false;
+    }
+    return static_cast<size_t>(-1);
+  }
+
   char lenStr[80];
   sprintf(lenStr, "%ld -> %ld", len, result);
   Logger.debug(SOCKET_IMPL, "read->", lenStr);
@@ -139,7 +268,11 @@ int SocketImpl::peek() {
 
 void SocketImpl::close() {
   Logger.info(SOCKET_IMPL, "close");
-  ::close(sock);
+  if (sock >= 0) {
+    ::close(sock);
+    sock = -1;
+  }
+  is_connected = false;
 }
 
 // Linux-compatible implementation: parse /proc/net/route for default interface

--- a/ArduinoCore-Linux/cores/arduino/SocketImpl.cpp
+++ b/ArduinoCore-Linux/cores/arduino/SocketImpl.cpp
@@ -229,10 +229,10 @@ size_t SocketImpl::available() {
 }
 
 // direct read
-size_t SocketImpl::read(uint8_t *buffer, size_t len) {
+int SocketImpl::read(uint8_t *buffer, size_t len) {
   if (sock < 0) {
     is_connected = false;
-    return static_cast<size_t>(-1);
+    return -1;
   }
 
   ssize_t result = ::recv(sock, buffer, len, MSG_DONTWAIT | MSG_NOSIGNAL);
@@ -240,21 +240,24 @@ size_t SocketImpl::read(uint8_t *buffer, size_t len) {
     Logger.info(SOCKET_IMPL, "read EOF");
     close();
     is_connected = false;
-    return static_cast<size_t>(-1);
+    return -1;
   }
 
   if (result < 0) {
-    if (errno != EAGAIN && errno != EWOULDBLOCK) {
-      close();
-      is_connected = false;
+    if (errno == EAGAIN || errno == EWOULDBLOCK) {
+      return 0;
     }
-    return static_cast<size_t>(-1);
+
+    close();
+    is_connected = false;
+    return -1;
   }
 
   char lenStr[80];
   sprintf(lenStr, "%ld -> %ld", len, result);
   Logger.debug(SOCKET_IMPL, "read->", lenStr);
-  return result;
+  // Possible narrowing can't be helped because of Arduino API compatiblity
+  return static_cast<int>(result);
 }
 
 // peeks one character

--- a/ArduinoCore-Linux/cores/arduino/SocketImpl.h
+++ b/ArduinoCore-Linux/cores/arduino/SocketImpl.h
@@ -52,7 +52,7 @@ class SocketImpl {
   // provides the available bytes
   virtual size_t available();
   // direct read
-  virtual size_t read(uint8_t* buffer, size_t len);
+  virtual int read(uint8_t* buffer, size_t len);
   // peeks one character
   virtual int peek();
   // coloses the connection

--- a/ArduinoCore-Linux/cores/arduino/SocketImpl.h
+++ b/ArduinoCore-Linux/cores/arduino/SocketImpl.h
@@ -45,6 +45,8 @@ class SocketImpl {
   virtual uint8_t connected();
   // opens a conection
   virtual int connect(const char* address, uint16_t port);
+  // opens a connection with a timeout in milliseconds
+  virtual int connect(const char* address, uint16_t port, int32_t timeout_ms);
   // sends some data
   virtual size_t write(const uint8_t* str, size_t len);
   // provides the available bytes

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -6,6 +6,7 @@ add_subdirectory("spi")
 add_subdirectory("serial2")
 add_subdirectory("using-arduino-library")
 add_subdirectory("pwm")
+add_subdirectory("network-connect-timing")
 
 # BME280 Sensor Examples
 arduino_library(SparkFunBME280 "https://github.com/sparkfun/SparkFun_BME280_Arduino_Library" )

--- a/examples/network-connect-timing/CMakeLists.txt
+++ b/examples/network-connect-timing/CMakeLists.txt
@@ -1,0 +1,5 @@
+arduino_sketch(network-connect-timing network-connect-timing.ino)
+
+if(APPLE)
+	target_compile_options(network-connect-timing PRIVATE -Wno-deprecated-declarations)
+endif()

--- a/examples/network-connect-timing/network-connect-timing.ino
+++ b/examples/network-connect-timing/network-connect-timing.ino
@@ -1,0 +1,183 @@
+/*
+  Network connect timing test.
+
+  There are three test setups to exercise different situations:
+
+  Instant connect failure:
+    For this test, there should be nothing listening on localhost port 8123
+
+    network-connect-timing should say "connect failed" with
+    elapsed=0ms or nearly 0.
+
+  Connect success:
+    Start a plain TCP listener locally, for example:
+      nc -lk 127.0.0.1 8123
+
+    network-connect-timing should say "connect succeeded",
+    display some send/response/connected/closed messages,
+    and the elapsed time should be 1000 ms or so.
+
+  Connect timeout:
+    For this test, you need to configure the host kernel to drop packets.
+    It does not matter if the listener is running or not.
+
+    On MacOS you can drop packets as follows:
+     Add this to /etc/pf.conf :
+      anchor "connect-timeout-test"
+      load anchor "connect-timeout-test" from "/etc/pf.anchors/connect-timeout-test"
+
+     Create a file /etc/pf.anchors/connect-timeout-test containing:
+      block drop quick on lo0 proto tcp from any to 127.0.0.1 port 8123
+      block drop quick on lo0 proto tcp from 127.0.0.1 to any port 8123
+    
+     Then run this to enable the rules:
+      sudo pfctl -f /etc/pf.conf              
+      sudo pfctl -e
+
+    For Linux you can drop packets by issuing:
+      sudo nft add table inet connect_test
+      sudo nft 'add chain inet connect_test output { type filter hook output priority 0; }'
+      sudo nft 'add chain inet connect_test input { type filter hook input priority 0; }'
+      sudo nft 'add rule inet connect_test output oifname "lo" tcp dport 8123 drop'
+      sudo nft 'add rule inet connect_test input iifname "lo" tcp sport 8123 drop'
+
+    With those packet-dropping rules in place,
+     network-connect-test should say "connect failed"
+     and the elapsed time should be a little more than 2000 ms
+     for the first test and 3000 ms for the second.
+*/
+
+#include <Arduino.h>
+#include <WiFi.h>
+#include <WiFiClient.h>
+
+namespace {
+
+constexpr const char* ssid = "localhost-test";
+constexpr const char* password = "unused";
+constexpr const char* host = "127.0.0.1";
+constexpr uint16_t port = 8123;
+constexpr int32_t explicit_connect_timeout_ms = 2000;
+constexpr int32_t default_connect_timeout_ms = 3000;
+constexpr unsigned long read_timeout_ms = 1000;
+
+WiFiClient explicit_timeout_client;
+WiFiClient default_timeout_client;
+
+void print_test_elapsed(const char* label, unsigned long start_ms) {
+  Serial.print(label);
+  Serial.print(" elapsed=");
+  Serial.print(millis() - start_ms);
+  Serial.println("ms");
+}
+
+void wait_for_wifi() {
+  Serial.print("Attempting to connect to SSID: ");
+  Serial.println(ssid);
+  WiFi.begin(ssid, password);
+  Serial.print("Connected to ");
+  Serial.println(ssid);
+  Serial.println();
+}
+
+bool connect_with_explicit_timeout() {
+  Serial.print("Connecting with explicit timeout to ");
+  Serial.print(host);
+  Serial.print(":");
+  Serial.print(port);
+  Serial.print(" timeout=");
+  Serial.print(explicit_connect_timeout_ms);
+  Serial.println("ms");
+
+  if (!explicit_timeout_client.connect(host, port, explicit_connect_timeout_ms)) {
+    Serial.println("Explicit-timeout connect failed");
+    return false;
+  }
+
+  Serial.println("Explicit-timeout connect succeeded");
+  return true;
+}
+
+bool connect_with_default_timeout() {
+  default_timeout_client.setConnectionTimeout(default_connect_timeout_ms);
+
+  Serial.print("Connecting with default connect(host, port) using timeout=");
+  Serial.print(default_connect_timeout_ms);
+  Serial.println("ms");
+
+  if (!default_timeout_client.connect(host, port)) {
+    Serial.println("Default-timeout connect failed");
+    return false;
+  }
+
+  Serial.println("Default-timeout connect succeeded");
+  return true;
+}
+
+void send_plain_text(WiFiClient& client, const char* label) {
+  Serial.print(label);
+  client.println("hello from WiFiClient");
+}
+
+void drain_input(WiFiClient& client, const char* label) {
+  unsigned long deadline = millis() + read_timeout_ms;
+
+  Serial.print(label);
+  Serial.println(" waiting for response bytes");
+
+  while (client.connected() && millis() < deadline) {
+    while (client.available() > 0) {
+      int ch = client.read();
+      if (ch >= 0) {
+        Serial.write(static_cast<char>(ch));
+        deadline = millis() + read_timeout_ms;
+      }
+    }
+    delay(10);
+  }
+
+  Serial.println();
+  Serial.print(label);
+  Serial.print(" connected() -> ");
+  Serial.println(client.connected() ? "true" : "false");
+}
+
+void close_client(WiFiClient& client, const char* label) {
+  client.stop();
+  Serial.print(label);
+  Serial.println(" closed");
+}
+
+}  // namespace
+
+void setup() {
+  Serial.begin(115200);
+  delay(100);
+
+  wait_for_wifi();
+
+  unsigned long explicit_test_start_ms = millis();
+  if (connect_with_explicit_timeout()) {
+    send_plain_text(explicit_timeout_client, "explicit_timeout_client");
+    drain_input(explicit_timeout_client, "explicit_timeout_client");
+    close_client(explicit_timeout_client, "explicit_timeout_client");
+  }
+  print_test_elapsed("explicit-timeout test", explicit_test_start_ms);
+  Serial.println();
+
+  unsigned long default_test_start_ms = millis();
+  if (connect_with_default_timeout()) {
+    send_plain_text(default_timeout_client, "default_timeout_client");
+    drain_input(default_timeout_client, "default_timeout_client");
+    close_client(default_timeout_client, "default_timeout_client");
+  }
+  print_test_elapsed("default-timeout test", default_test_start_ms);
+
+  Serial.println();
+  Serial.println("network-connect-timing test complete");
+}
+
+void loop() {
+  exit(0);
+  // delay(1000);
+}


### PR DESCRIPTION
## Summary

Align `WiFiClient/EthernetClient`/`SocketImpl` connection behavior with ESP32 and Arduino-Pico client semantics.

## Why

Cross-platform Arduino code expects two things that were not true in Arduino-Emulator:

- `connected()` should be a fast status probe, not a multi-second wait before returning `false`
- `connect()` should be timeout-bounded in a way that matches mainstream Arduino network client behavior

## Changes

- Make `connected()` fail fast on disconnect
- Treat `recv(..., MSG_PEEK) == 0` as peer close
- Clear socket state on close
- Add `connect(..., timeout_ms)` overloads as with the ESP core
- Make default `connect()` use the configured connection timeout as with the Pico core
- Return failure correctly when socket connect fails

## Compatibility

This brings Arduino-Emulator closer to other cores:

- connected() has the same fast-probe behavior as other cores
- The connect() API is the same as for ESP, and a superset of Pico
- The connect() timeout behavior when DNS name resolution is used follows the ESP pattern, in which the name resolution step has a separate timeout that is controlled only by the lower level networking component (lwip for ESP with a baked-in 15 second timeout, system networking for Emulator configurable at the system level through e.g. resolv.conf).  The Pico core behaves a little differently, in that the supplied  timeout value is passed through to the resolver, and then separately applied to the later connect step.  Implementing the Pico model would require introducing a separate thread because getaddrbyname() has no adjustable-time-limit version.
